### PR TITLE
Add logic to deduplicate complementarity vector efficiently

### DIFF
--- a/src/+mpecopt/Solver.m
+++ b/src/+mpecopt/Solver.m
@@ -1901,7 +1901,11 @@ function X = all_combinations(varargin)
     X = zeros(prod(sizeThisSet),numSets);
     for i=1:size(X,1)
         ixVect = cell(length(sizeThisSet),1);
-        [ixVect{:}] = ind2sub(flip(sizeThisSet),i);
+        sz = flip(sizeThisSet);
+        if length(sz) == 1
+            sz = [sz,1];
+        end
+        [ixVect{:}] = ind2sub(sz,i);
         ixVect = flip([ixVect{:}]);
         vect = zeros(1, numSets);
         for jj=1:numSets


### PR DESCRIPTION
Currently if the G or H vector contains duplicates we throw errors (as happens in e.g. cross-complementarity).

Here we use the casadi element hashes to deduplicate this list first when calculating the index sets.